### PR TITLE
Fix failure condition on 0 rules found

### DIFF
--- a/src/promtool_check.sh
+++ b/src/promtool_check.sh
@@ -17,7 +17,7 @@ function promtool_check {
       check_exit_code=${?}
 
       # no rules round - failure
-      if [[ $check_output == *"SUCCESS: 0 rules found" ]]; then
+      if [[ ${check_output} == *"0 rules found"* ]]; then
           check_comment_status="Failed"
           echo "check: error: failed to execute \`promtool check ${prom_check_subcommand}\` for ${c}."
           echo "${check_output}"


### PR DESCRIPTION
# WHAT

We are still succeeding this promtool action even though there are 0 rules found
https://github.com/bisontrails/infrastructure/pull/1705

I think it may be because this check is a little too strict, we should add another `*` to the end so that we can allow for new line characters.

The message is
```
modules/prometheus/common/alerts/control/resource_manager.yaml:
Checking /dev/fd/63
  SUCCESS: 0 rules found
 ```