### PR TITLE
fix(promtool-action): Correct check for "0 rules"

### DIFF
--- a/src/promtool_check.sh
+++ b/src/promtool_check.sh
@@ -17,7 +17,7 @@ function promtool_check {
       check_exit_code=${?}
 
       # no rules round - failure
-      if [[ ${check_output} == *"0 rules found"* ]]; then
+      if [[ ${check_output} == *" 0 rules found"* ]]; then
           check_comment_status="Failed"
           echo "check: error: failed to execute \`promtool check ${prom_check_subcommand}\` for ${c}."
           echo "${check_output}"


### PR DESCRIPTION
# What

We loosened up the check in Bash a bit, and it broke checks for
when we have 10, 20, 30, etc. rules. That's not desired.

# Testing

Tested this locally, but not in the live system, because it's
hard to test GitHub Actions. ¯\_(ツ)_/¯