### PR TITLE
moved check_exit_code to be after check_output

### DIFF
--- a/src/promtool_check.sh
+++ b/src/promtool_check.sh
@@ -13,8 +13,8 @@ function promtool_check {
     full_output=""
     for c in $changed_files; do
       check_output="$(promtool check "${prom_check_subcommand}" <(oq -i yaml '{"groups": .}' "${c}"))"
-      full_output="${c}:\n${check_output}\n${full_output}"
       check_exit_code=${?}
+      full_output="${c}:\n${check_output}\n${full_output}"
 
       # no rules round - failure
       if [[ ${check_output} == *" 0 rules found"* ]]; then


### PR DESCRIPTION
In it's current form the script will never exit on failure due to failed check_output. This resolves that issue and returns desired behavior. 